### PR TITLE
Do not save payment record when payment has expired

### DIFF
--- a/payment/views/stripe.py
+++ b/payment/views/stripe.py
@@ -71,15 +71,4 @@ def webhook(request):
                 payable_object.complete_transaction(event_data)
         except Exception as error:
             return HttpResponseServerError(error)
-    # Save payment records for 'unpaid' payments, which are returned in expired checkout sessions
-    elif event['type'] == 'checkout.session.expired':
-        event_data = event['data']['object']
-        payable_id = int(event_data['metadata']['payable_id'])
-        payable_object = apps.get_model('student', event_data['metadata']['payable_type']).objects.get(pk=payable_id)
-
-        try:
-            with transaction.atomic():
-                payable_object.record_stripe_payment(event_data)
-        except IntegrityError:
-            return HttpResponseServerError()
     return HttpResponse(status=200)


### PR DESCRIPTION
- This is because customer details can sometimes be blank when a payment has expired. In such cases, there is no real need to save the record since the transaction did not go through and the details can be seen in Stripe dashboard anyway